### PR TITLE
support custom urls to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 ## Checkers list
 - **RU :: TCP 16-20** => [https://hyperion-cs.github.io/dpi-checkers/ru/tcp-16-20](https://hyperion-cs.github.io/dpi-checkers/ru/tcp-16-20)<br>
 Allows to detect TCP 16-20 blocking method in Russia. The tests use publicly available APIs of popular services hosted by providers whose subnets are potentially subject to limitations. The testing process runs right in your browser and the source code is available. VPN should be disabled during the check.<br>
-See [here](https://github.com/net4people/bbs/issues/490) for more details.
 
-- **RU :: TCP 16-20 [Custom]** => You can pass custom address to check (for example, your steal-oneself page) via url path params: `.../ru/tcp-16-20/?url=custom-testing-page.html`. Testing `custom-testing-page.html` should allow cross-origin requests and be more than 128 Kb sized.
+    See [here](https://github.com/net4people/bbs/issues/490) for more details.
+
+    This checker has optional GET parameters:
+
+    | name | type |	default	| description |
+    |-|-|-|-|
+    | url | string | empty | A custom endpoint to check in addition to the default ones (e.g. your steal-oneself server). Testing custom-testing-page.html should allow cross-origin requests and should provide than 64KB of transferred data. When not specified, the times and provider options are ignored. |
+    | times | int | 1 | How many times to access the endpoint in a single HTTP connection (keep-alived). |
+    | provider | string | Custom | Provider Name (you can set any name). |
+    ||
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 Allows to detect TCP 16-20 blocking method in Russia. The tests use publicly available APIs of popular services hosted by providers whose subnets are potentially subject to limitations. The testing process runs right in your browser and the source code is available. VPN should be disabled during the check.<br>
 See [here](https://github.com/net4people/bbs/issues/490) for more details.
 
+- **RU :: TCP 16-20 [Custom]** => You can pass custom address to check (for example, your steal-oneself page) via url path params: `.../ru/tcp-16-20/?url=custom-testing-page.html`. Testing `custom-testing-page.html` should allow cross-origin requests and be more than 128 Kb sized.
+
+
 ## Contributing
 We would be happy if you could help us improve our checkers through PR or by creating issues.
 Also you can star the repository so you don't lose the checkers.

--- a/ru/tcp-16-20/index.html
+++ b/ru/tcp-16-20/index.html
@@ -68,7 +68,7 @@
         const times = parseInt(params.get("times")) || 1;
 
         const newTest = {
-          id: `CUST-${TEST_SUITE.length + 1}`,
+          id: `CUST-01`,
           provider: provider,
           times: times,
           url: url,

--- a/ru/tcp-16-20/index.html
+++ b/ru/tcp-16-20/index.html
@@ -58,6 +58,27 @@
       { id: "OVH-01", provider: "OVH", times: 1, url: "https://eu.api.ovh.com/console/rapidoc-min.js" },
     ];
 
+    // add custom test suite if provided
+    (function appendCustomTestFromQuery() {
+      const params = new URLSearchParams(window.location.search);
+      const url = params.get("url");
+
+      if (url) {
+        const provider = params.get("provider") || "Custom";
+        const times = parseInt(params.get("times")) || 1;
+
+        const newTest = {
+          id: `CUST-${TEST_SUITE.length + 1}`,
+          provider: provider,
+          times: times,
+          url: url,
+        };
+
+        TEST_SUITE.push(newTest);
+        console.log("Custom test added:", newTest);
+      }
+    })();
+
     const TIMEOUT_MS = 5000;
     const OK_THRESHOLD_BYTES = 64 * 1024;
 


### PR DESCRIPTION
Now you can pass custom address to check (for example, your steal-oneself page) via url path params: `.../ru/tcp-16-20/?url=custom-testing-page.html`. Testing custom-testing-page.html should allow cross-origin requests and be more than 128 Kb sized.