### PR TITLE
`dpi-ch/inetutil` add iface option

### DIFF
--- a/ru/dpi-ch/checkers/cidrwhitelist.go
+++ b/ru/dpi-ch/checkers/cidrwhitelist.go
@@ -5,7 +5,6 @@ package checkers
 import (
 	"context"
 	"errors"
-	"net/http"
 	"sync"
 	"sync/atomic"
 
@@ -30,7 +29,7 @@ func CidrWhitelist() error {
 
 	for _, url := range cfg.Regular {
 		wg.Go(func() {
-			if err := inetutil.Head(regCtx, http.DefaultClient, url, true, true); err == nil {
+			if err := inetutil.Head(regCtx, url, true, true); err == nil {
 				regCancel()
 				wlCancel() // results are already clear
 				atomic.AddInt32(&regCount, 1)
@@ -40,7 +39,7 @@ func CidrWhitelist() error {
 
 	for _, url := range cfg.Whitelisted {
 		wg.Go(func() {
-			if err := inetutil.Head(wlCtx, http.DefaultClient, url, true, true); err == nil {
+			if err := inetutil.Head(wlCtx, url, true, true); err == nil {
 				wlCancel()
 				atomic.AddInt32(&wlCount, 1)
 			}

--- a/ru/dpi-ch/checkers/cidrwhitelist.go
+++ b/ru/dpi-ch/checkers/cidrwhitelist.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 )
 
 var ErrCidrWhitelistDetected = errors.New("cidr whitelist detected")
@@ -30,7 +30,7 @@ func CidrWhitelist() error {
 
 	for _, url := range cfg.Regular {
 		wg.Go(func() {
-			if err := httputil.Head(regCtx, http.DefaultClient, url, true, true); err == nil {
+			if err := inetutil.Head(regCtx, http.DefaultClient, url, true, true); err == nil {
 				regCancel()
 				wlCancel() // results are already clear
 				atomic.AddInt32(&regCount, 1)
@@ -40,7 +40,7 @@ func CidrWhitelist() error {
 
 	for _, url := range cfg.Whitelisted {
 		wg.Go(func() {
-			if err := httputil.Head(wlCtx, http.DefaultClient, url, true, true); err == nil {
+			if err := inetutil.Head(wlCtx, http.DefaultClient, url, true, true); err == nil {
 				wlCancel()
 				atomic.AddInt32(&wlCount, 1)
 			}

--- a/ru/dpi-ch/checkers/dns.go
+++ b/ru/dpi-ch/checkers/dns.go
@@ -16,8 +16,8 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetlookup"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/subnetfilter"
 )
 
@@ -132,7 +132,7 @@ func dnsDohRaw(ctx context.Context, target DnsTarget, resolverHostname string, r
 	innerCtx, cancel := context.WithTimeout(ctx, cfg.DohOpt.Timeout)
 	defer cancel()
 
-	tlsConnOpt := httputil.TlsConnOpt{
+	tlsConnOpt := inetutil.TlsConnOpt{
 		Ctx:            innerCtx,
 		Ip:             resolverIp,
 		Port:           443, // TODO: config that
@@ -140,10 +140,10 @@ func dnsDohRaw(ctx context.Context, target DnsTarget, resolverHostname string, r
 		InsecureVerify: true,
 	}
 
-	tlsConn, err := httputil.GetHandshakedUTlsConn(tlsConnOpt)
+	tlsConn, err := inetutil.GetHandshakedUTlsConn(tlsConnOpt)
 	if err != nil {
 		res.Err = err
-		if err == httputil.ErrTlsCertificateInvalid {
+		if err == inetutil.ErrTlsCertificateInvalid {
 			res.Err = ErrDnsDohInsecure
 		}
 
@@ -165,14 +165,14 @@ func dnsDohRaw(ctx context.Context, target DnsTarget, resolverHostname string, r
 	req.Close = true // TODO: it is better to keep one connection open to each resolver
 	req.Header.Set("Content-Type", "application/dns-message")
 
-	httputil.SetHeaders(&req.Header, cfg.DohOpt.HttpStaticHeaders)
+	inetutil.SetHeaders(&req.Header, cfg.DohOpt.HttpStaticHeaders)
 
-	if _, err := httputil.TlsWriteHttpRequest(innerCtx, tlsConn, req); err != nil {
+	if _, err := inetutil.TlsWriteHttpRequest(innerCtx, tlsConn, req); err != nil {
 		res.Err = err
 		return res
 	}
 
-	resp, err := httputil.TlsReadHttpResponse(innerCtx, tlsConn, bufio.NewReader(tlsConn))
+	resp, err := inetutil.TlsReadHttpResponse(innerCtx, tlsConn, bufio.NewReader(tlsConn))
 	if err != nil {
 		res.Err = err
 		return res
@@ -230,7 +230,7 @@ func plainErrImportance(err error) int {
 }
 
 func dohErrImportance(err error) int {
-	if httputil.IsHttputilErr(err) {
+	if inetutil.IsInetutilErr(err) {
 		return 3
 	}
 	switch err {
@@ -291,7 +291,7 @@ func dnsLeakSingle() dnsLeakOut {
 
 	url := "https://" + randString(cfg.Leak.LabelAlpha, cfg.Leak.LabelLen) + "." + cfg.Leak.ParentDomain
 	var respRaw map[string][]string
-	if err := httputil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, true); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, true); err != nil {
 		return dnsLeakOut{nil, err}
 	}
 

--- a/ru/dpi-ch/checkers/dns.go
+++ b/ru/dpi-ch/checkers/dns.go
@@ -291,7 +291,7 @@ func dnsLeakSingle() dnsLeakOut {
 
 	url := "https://" + randString(cfg.Leak.LabelAlpha, cfg.Leak.LabelLen) + "." + cfg.Leak.ParentDomain
 	var respRaw map[string][]string
-	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, true); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, url, &respRaw, true, true); err != nil {
 		return dnsLeakOut{nil, err}
 	}
 

--- a/ru/dpi-ch/checkers/webhost.go
+++ b/ru/dpi-ch/checkers/webhost.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetlookup"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 
 	tls "github.com/refraction-networking/utls"
 )
@@ -77,7 +77,7 @@ func WebhostSingle(opt WebhostSingleOpt) WebhostSingleResult {
 	}
 
 	cfg := config.Get().Checkers.Webhost
-	tlsConnOpt := httputil.TlsConnOpt{
+	tlsConnOpt := inetutil.TlsConnOpt{
 		Ip:                  opt.Ip,
 		Port:                opt.Port,
 		Sni:                 opt.Sni,
@@ -88,7 +88,7 @@ func WebhostSingle(opt WebhostSingleOpt) WebhostSingleResult {
 		KeyLogWriter:        opt.KeyLogWriter,
 	}
 
-	tlsConn, err := httputil.GetHandshakedUTlsConn(tlsConnOpt)
+	tlsConn, err := inetutil.GetHandshakedUTlsConn(tlsConnOpt)
 	if err != nil {
 		res.Alive = err
 		res.Tcp1620 = ErrWebhostSkip
@@ -106,7 +106,7 @@ func WebhostSingle(opt WebhostSingleOpt) WebhostSingleResult {
 		return res
 	}
 
-	tlsConn, err = httputil.GetHandshakedUTlsConn(tlsConnOpt)
+	tlsConn, err = inetutil.GetHandshakedUTlsConn(tlsConnOpt)
 	if err != nil {
 		res.Tcp1620 = err
 		return res
@@ -130,17 +130,17 @@ func webhostAliveCheck(opt WebhostSingleOpt, tlsConn *tls.UConn) error {
 		return err
 	}
 	req.Close = true
-	httputil.SetHeaders(&req.Header, cfg.HttpStaticHeaders)
+	inetutil.SetHeaders(&req.Header, cfg.HttpStaticHeaders)
 
 	writeCtx, cancel := context.WithTimeout(context.Background(), cfg.TcpWriteTimeout)
 	defer cancel()
-	if _, err := httputil.TlsWriteHttpRequest(writeCtx, tlsConn, req); err != nil {
+	if _, err := inetutil.TlsWriteHttpRequest(writeCtx, tlsConn, req); err != nil {
 		return err
 	}
 
 	readCtx, cancel := context.WithTimeout(context.Background(), cfg.TcpReadTimeout)
 	defer cancel()
-	resp, err := httputil.TlsReadHttpResponse(readCtx, tlsConn, bufio.NewReader(tlsConn))
+	resp, err := inetutil.TlsReadHttpResponse(readCtx, tlsConn, bufio.NewReader(tlsConn))
 	if err != nil {
 		return err
 	}
@@ -160,12 +160,12 @@ func webhostTcp1620check(opt WebhostSingleOpt, tlsConn *tls.UConn) (WebhostThrou
 		return WebhostThroughput{}, err
 	}
 	req.Close = false
-	httputil.SetHeaders(&req.Header, cfg.HttpStaticHeaders)
+	inetutil.SetHeaders(&req.Header, cfg.HttpStaticHeaders)
 
 	writeCtx, cancel := context.WithTimeout(context.Background(), cfg.TcpWriteTimeout)
 	defer cancel()
 	txStart := time.Now()
-	txBytes, err := httputil.TlsWriteHttpRequest(writeCtx, tlsConn, req)
+	txBytes, err := inetutil.TlsWriteHttpRequest(writeCtx, tlsConn, req)
 	if err != nil {
 		return WebhostThroughput{}, err
 	}
@@ -173,9 +173,9 @@ func webhostTcp1620check(opt WebhostSingleOpt, tlsConn *tls.UConn) (WebhostThrou
 
 	readCtx, cancel := context.WithTimeout(context.Background(), cfg.TcpReadTimeout)
 	defer cancel()
-	rxCr := &httputil.CountingReader{Reader: tlsConn}
+	rxCr := &inetutil.CountingReader{Reader: tlsConn}
 	rxStart := time.Now()
-	resp, err := httputil.TlsReadHttpResponse(readCtx, tlsConn, bufio.NewReader(rxCr))
+	resp, err := inetutil.TlsReadHttpResponse(readCtx, tlsConn, bufio.NewReader(rxCr))
 	if err != nil {
 		return WebhostThroughput{}, err
 	}

--- a/ru/dpi-ch/config/config.go
+++ b/ru/dpi-ch/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	} `mapstructure:"inetlookup-geolitecsv"`
 
 	InetUtil struct {
+		Iface          string            `mapstructure:"iface"`
 		BrowserHeaders map[string]string `mapstructure:"browser-headers"`
 	} `mapstructure:"inetutil"`
 

--- a/ru/dpi-ch/config/config.go
+++ b/ru/dpi-ch/config/config.go
@@ -103,9 +103,9 @@ type Config struct {
 		GeonameidCountry string `mapstructure:"geonameid-country"`
 	} `mapstructure:"inetlookup-geolitecsv"`
 
-	HttpUtil struct {
+	InetUtil struct {
 		BrowserHeaders map[string]string `mapstructure:"browser-headers"`
-	} `mapstructure:"httputil"`
+	} `mapstructure:"inetutil"`
 
 	Updater struct {
 		Enabled               bool          `mapstructure:"enabled"`

--- a/ru/dpi-ch/config/default.yaml
+++ b/ru/dpi-ch/config/default.yaml
@@ -206,6 +206,7 @@ inetlookup-geolitecsv:
   geonameid-country: ./data/geolite/geonameid-country.csv
 
 inetutil:
+  iface: "" # empty is default network interface
   browser-headers:
     Accept-Language: ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7
     User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36

--- a/ru/dpi-ch/config/default.yaml
+++ b/ru/dpi-ch/config/default.yaml
@@ -205,7 +205,7 @@ inetlookup-geolitecsv:
   cidr-country: ./data/geolite/cidr-country.csv
   geonameid-country: ./data/geolite/geonameid-country.csv
 
-httputil:
+inetutil:
   browser-headers:
     Accept-Language: ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7
     User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36

--- a/ru/dpi-ch/docs/README.md
+++ b/ru/dpi-ch/docs/README.md
@@ -172,7 +172,8 @@ webhostfarm: # takes sets of subnets (usually from subnetfilter), returns suitab
   tcp-conn-timeout:      # time.Duration; timeout for establishing a tcp connection
   tls-handshake-timeout: # time.Duration; timeout for tls handshake
 
-httputil: # used to perform simple http requests
+inetutil: # used for all network operations (incl. tcp/tls operation and http requests)
+  iface:           # string; name of network interface or its ip address for network operations (currently, only ipv4 is supported)
   browser-headers: # map[string]string; http headers that will be sent as part of requests
 
 updater: # used to automatically update the dpi-ch utility and related stuff (e.g., geoip)

--- a/ru/dpi-ch/inetlookup/common.go
+++ b/ru/dpi-ch/inetlookup/common.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 )
 
 var mu sync.Mutex
@@ -52,7 +52,7 @@ func GetExternalIpViaRipe(ctx context.Context) (netip.Addr, error) {
 	cfg := config.Get().InetLookup
 
 	var ipRaw struct{ Data struct{ Ip string } }
-	if err := httputil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.RipeApiUrl+"whats-my-ip/data.json", &ipRaw, true, true); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.RipeApiUrl+"whats-my-ip/data.json", &ipRaw, true, true); err != nil {
 		return netip.Addr{}, err
 	}
 
@@ -63,7 +63,7 @@ func GetExternalIpViaYandex(ctx context.Context) (netip.Addr, error) {
 	cfg := config.Get().InetLookup
 
 	var ip string
-	err := httputil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.YandexApiUrl+"ip", &ip, true, true)
+	err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.YandexApiUrl+"ip", &ip, true, true)
 	if err != nil {
 		return netip.Addr{}, err
 	}

--- a/ru/dpi-ch/inetlookup/common.go
+++ b/ru/dpi-ch/inetlookup/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"net/netip"
 	"os"
 	"path"
@@ -52,7 +51,7 @@ func GetExternalIpViaRipe(ctx context.Context) (netip.Addr, error) {
 	cfg := config.Get().InetLookup
 
 	var ipRaw struct{ Data struct{ Ip string } }
-	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.RipeApiUrl+"whats-my-ip/data.json", &ipRaw, true, true); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, cfg.RipeApiUrl+"whats-my-ip/data.json", &ipRaw, true, true); err != nil {
 		return netip.Addr{}, err
 	}
 
@@ -63,7 +62,7 @@ func GetExternalIpViaYandex(ctx context.Context) (netip.Addr, error) {
 	cfg := config.Get().InetLookup
 
 	var ip string
-	err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, cfg.YandexApiUrl+"ip", &ip, true, true)
+	err := inetutil.GetAndUnmarshal(ctx, cfg.YandexApiUrl+"ip", &ip, true, true)
 	if err != nil {
 		return netip.Addr{}, err
 	}

--- a/ru/dpi-ch/inetutil/countingreader.go
+++ b/ru/dpi-ch/inetutil/countingreader.go
@@ -1,4 +1,4 @@
-package httputil
+package inetutil
 
 import "io"
 

--- a/ru/dpi-ch/inetutil/http.go
+++ b/ru/dpi-ch/inetutil/http.go
@@ -1,4 +1,4 @@
-package httputil
+package inetutil
 
 import (
 	"context"
@@ -74,6 +74,6 @@ func SetHeaders(out *http.Header, headers map[string]string) {
 }
 
 func setBrowserHeaders(out *http.Header) {
-	cfg := config.Get().HttpUtil
+	cfg := config.Get().InetUtil
 	SetHeaders(out, cfg.BrowserHeaders)
 }

--- a/ru/dpi-ch/inetutil/http.go
+++ b/ru/dpi-ch/inetutil/http.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log"
+	"net"
 	"net/http"
+	"sync"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
 )
 
-func Head(ctx context.Context, client *http.Client, url string, browserHeaders bool, close bool) error {
+var (
+	httpMu     sync.Mutex
+	httpClient *http.Client
+)
+
+func Head(ctx context.Context, url string, browserHeaders bool, close bool) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, http.NoBody)
 	req.Close = close
 	if err != nil {
@@ -20,7 +28,7 @@ func Head(ctx context.Context, client *http.Client, url string, browserHeaders b
 		setBrowserHeaders(&req.Header)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := httpDefaultClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -29,7 +37,7 @@ func Head(ctx context.Context, client *http.Client, url string, browserHeaders b
 	return nil
 }
 
-func Get(ctx context.Context, client *http.Client, url string, browserHeaders bool, close bool) ([]byte, error) {
+func Get(ctx context.Context, url string, browserHeaders bool, close bool) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	req.Close = close
 	if err != nil {
@@ -40,7 +48,7 @@ func Get(ctx context.Context, client *http.Client, url string, browserHeaders bo
 		setBrowserHeaders(&req.Header)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := httpDefaultClient().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +62,8 @@ func Get(ctx context.Context, client *http.Client, url string, browserHeaders bo
 	return body, nil
 }
 
-func GetAndUnmarshal[T any](ctx context.Context, client *http.Client, url string, v *T, browserHeaders bool, close bool) error {
-	body, err := Get(ctx, client, url, browserHeaders, close)
+func GetAndUnmarshal[T any](ctx context.Context, url string, v *T, browserHeaders bool, close bool) error {
+	body, err := Get(ctx, url, browserHeaders, close)
 	if err != nil {
 		return err
 	}
@@ -76,4 +84,27 @@ func SetHeaders(out *http.Header, headers map[string]string) {
 func setBrowserHeaders(out *http.Header) {
 	cfg := config.Get().InetUtil
 	SetHeaders(out, cfg.BrowserHeaders)
+}
+
+// Returns default http client for inetutil package, considering network interface options in config.
+func httpDefaultClient() *http.Client {
+	httpMu.Lock()
+	defer httpMu.Unlock()
+
+	if httpClient == nil {
+		tcpDialer := net.Dialer{}
+		if ifaceAddr, err := Iface4(); err == nil {
+			tcpDialer.LocalAddr = &net.TCPAddr{
+				IP:   net.IP(ifaceAddr.AsSlice()),
+				Port: 0,
+			}
+			log.Println("inetutil/http", "network interface specified", ifaceAddr)
+		}
+
+		httpClient = &http.Client{
+			Transport: &http.Transport{DialContext: tcpDialer.DialContext},
+		}
+	}
+
+	return httpClient
 }

--- a/ru/dpi-ch/inetutil/iface.go
+++ b/ru/dpi-ch/inetutil/iface.go
@@ -1,0 +1,69 @@
+package inetutil
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/netip"
+
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
+)
+
+var (
+	ErrIfaceNoSpecified       = errors.New("no network interface specified")
+	ErrIfaceIp4Only           = errors.New("only ipv4 is supported")
+	ErrIfaceIp4NotFoundByName = errors.New("no ipv4 address found in network interface with specified name")
+)
+
+// Returns ipv4 of network interface (specified in config),
+// or ErrIfaceNoSpecified error if it is not specified.
+func Iface4() (netip.Addr, error) {
+	cfg := config.Get().InetUtil
+	if cfg.Iface == "" {
+		log.Println("inetutil/iface/4", ErrIfaceNoSpecified, cfg.Iface)
+		return netip.Addr{}, ErrIfaceNoSpecified
+	}
+
+	if addr, err := netip.ParseAddr(cfg.Iface); err == nil {
+		if !addr.Is4() {
+			log.Println("inetutil/iface/4", ErrIfaceIp4Only, cfg.Iface)
+			return netip.Addr{}, ErrIfaceIp4Only
+		}
+		return addr, nil
+	}
+
+	addr, err := IfaceNameToIp4(cfg.Iface)
+	if err != nil {
+		log.Println("inetutil/iface/4", err, cfg.Iface)
+		return netip.Addr{}, err
+	}
+
+	return addr, nil
+}
+
+// Returns first ipv4 address found for network interface by name.
+func IfaceNameToIp4(name string) (netip.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			ipv4 := ipnet.IP.To4()
+			if ipv4 == nil {
+				continue
+			}
+
+			x, _ := netip.AddrFromSlice(ipv4)
+			return x, nil
+		}
+	}
+
+	return netip.Addr{}, ErrIfaceIp4NotFoundByName
+}

--- a/ru/dpi-ch/inetutil/tls.go
+++ b/ru/dpi-ch/inetutil/tls.go
@@ -1,4 +1,4 @@
-package httputil
+package inetutil
 
 import (
 	"bufio"
@@ -187,7 +187,7 @@ func TlsWriteHttpRequest(ctx context.Context, tlsConn *tls.UConn, req *http.Requ
 	return n, nil
 }
 
-func IsHttputilErr(err error) bool {
+func IsInetutilErr(err error) bool {
 	switch err {
 	case ErrTcpConnReset, ErrTcpConnTimeout, ErrTcpWriteTimeout,
 		ErrTcpReadTimeout, ErrTlsCertificateInvalid, ErrTlsHandshakeTimeout,

--- a/ru/dpi-ch/inetutil/tls.go
+++ b/ru/dpi-ch/inetutil/tls.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tls "github.com/refraction-networking/utls"
@@ -29,6 +30,10 @@ var (
 	ErrTlsBadRecordMac       = errors.New("tls: bad record MAC")
 	ErrTlsWriteBrokenPipe    = errors.New("tls: broken write pipe")
 	ErrInternal              = errors.New("net: internal error")
+
+	tlsMu                     sync.Mutex
+	tlsDialerLocalAddr        net.Addr
+	tlsDialerLocalAddrHandled bool
 )
 
 type TlsConnOpt struct {
@@ -49,7 +54,7 @@ type TlsConnOpt struct {
 // - Set tlsV
 // - Try to extract sni/host from cert
 func GetHandshakedUTlsConn(opt TlsConnOpt) (*tls.UConn, error) {
-	tcpDialer := net.Dialer{}
+	tcpDialer := net.Dialer{LocalAddr: tlsDefaultDialerLocalAddr()}
 	if opt.TcpConnTimeout != 0 {
 		tcpDialer.Timeout = opt.TcpConnTimeout
 	}
@@ -236,4 +241,24 @@ func tryHandleErr(err error) (error, bool) {
 	}
 
 	return err, false
+}
+
+// Returns default tls dialer local address for inetutil package, considering network interface options in config.
+func tlsDefaultDialerLocalAddr() net.Addr {
+	tlsMu.Lock()
+	defer tlsMu.Unlock()
+
+	if !tlsDialerLocalAddrHandled {
+		if ifaceAddr, err := Iface4(); err == nil {
+			tlsDialerLocalAddr = &net.TCPAddr{
+				IP:   net.IP(ifaceAddr.AsSlice()),
+				Port: 0,
+			}
+		}
+
+		log.Println("inetutil/tls", "network interface options handled", tlsDialerLocalAddr)
+		tlsDialerLocalAddrHandled = true
+	}
+
+	return tlsDialerLocalAddr
 }

--- a/ru/dpi-ch/tui/helper.go
+++ b/ru/dpi-ch/tui/helper.go
@@ -9,14 +9,14 @@ import (
 	"os"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/checkers"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 
 	"charm.land/bubbles/v2/table"
 	"charm.land/lipgloss/v2"
 )
 
 func dnsPrettyProviderVerdict(err error) string {
-	if httputil.IsHttputilErr(err) {
+	if inetutil.IsInetutilErr(err) {
 		return fmt.Sprintf("❗️ %s", err)
 	}
 
@@ -35,7 +35,7 @@ func dnsPrettyProviderVerdict(err error) string {
 		return "❗️bootstrap spoofing"
 	case checkers.ErrDnsDohBootstrapEmpty:
 		return "⚠️ empty bootstrap"
-	case checkers.ErrDnsDohInsecure, httputil.ErrTlsCertificateInvalid:
+	case checkers.ErrDnsDohInsecure, inetutil.ErrTlsCertificateInvalid:
 		return "❗️invalid https certificate"
 	case checkers.ErrDnsDohNon2xxResp:
 		return "⚠️ non-2xx response"
@@ -59,11 +59,11 @@ func webhostPrettyTcp1620(err error) string {
 	switch err {
 	case nil:
 		return "✅ no"
-	case httputil.ErrTcpWriteTimeout, httputil.ErrTcpReadTimeout:
+	case inetutil.ErrTcpWriteTimeout, inetutil.ErrTcpReadTimeout:
 		return "❗️detected"
 	case checkers.ErrWebhostSkip:
 		return "⚠️ skip"
-	case httputil.ErrTlsWriteBrokenPipe:
+	case inetutil.ErrTlsWriteBrokenPipe:
 		return "⚠️ not supported by host"
 	default:
 		return fmt.Sprintf("⚠️ %s", err)

--- a/ru/dpi-ch/tui/update.go
+++ b/ru/dpi-ch/tui/update.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/netip"
 	"slices"
 	"strings"
@@ -28,8 +27,6 @@ func (rm rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		k := msg.String()
-		log.Println("KeyPressMsg", k)
-
 		// this and other tea.ClearScreen; tmp workaround of https://github.com/charmbracelet/bubbletea/issues/1646
 		cmds = append(cmds, tea.ClearScreen)
 

--- a/ru/dpi-ch/updater/updater.go
+++ b/ru/dpi-ch/updater/updater.go
@@ -223,7 +223,7 @@ func readLocalHash(path string) (string, error) {
 func remoteHash(ctx context.Context, owner, repo, path, branch string) (string, error) {
 	url := attrUrl(owner, repo, path, branch)
 	var respRaw struct{ Sha string }
-	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, false); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, url, &respRaw, true, false); err != nil {
 		return "", err
 	}
 

--- a/ru/dpi-ch/updater/updater.go
+++ b/ru/dpi-ch/updater/updater.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/internal/version"
 )
 
@@ -223,7 +223,7 @@ func readLocalHash(path string) (string, error) {
 func remoteHash(ctx context.Context, owner, repo, path, branch string) (string, error) {
 	url := attrUrl(owner, repo, path, branch)
 	var respRaw struct{ Sha string }
-	if err := httputil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, false); err != nil {
+	if err := inetutil.GetAndUnmarshal(ctx, http.DefaultClient, url, &respRaw, true, false); err != nil {
 		return "", err
 	}
 

--- a/ru/dpi-ch/webhostfarm/webhostfarm.go
+++ b/ru/dpi-ch/webhostfarm/webhostfarm.go
@@ -6,7 +6,7 @@ import (
 	"net/netip"
 
 	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/config"
-	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/httputil"
+	"github.com/hyperion-cs/dpi-checkers/ru/dpi-ch/inetutil"
 
 	"go4.org/netipx"
 )
@@ -51,7 +51,7 @@ func Farm(opt FarmOpt) []FarmItem {
 
 func tryConnect(ip netip.Addr, port int, sni string) bool {
 	cfg := config.Get().WebhostFarm
-	conn, err := httputil.GetHandshakedUTlsConn(httputil.TlsConnOpt{
+	conn, err := inetutil.GetHandshakedUTlsConn(inetutil.TlsConnOpt{
 		Ip:                  ip,
 		Port:                port,
 		Sni:                 sni,


### PR DESCRIPTION
This PR allows to set a specific network interface — by name or ip address (currently, only ipv4 is supported) — in the configuration for handling all network operations in **dpi-ch**.  If this option is not specified, the default interface will be used.

Example in _config.yaml_:
```yaml
inetutil:
  iface: eth0
```

For more details, see the [documentation](https://github.com/hyperion-cs/dpi-checkers/tree/main/ru/dpi-ch/docs).